### PR TITLE
Fix Issue #2

### DIFF
--- a/content.js
+++ b/content.js
@@ -68,7 +68,14 @@
             if (!fileNameMatch) {
                 return "preview.pdf";
             }
-            return JSON.parse(fileNameMatch[1]);
+            let fileName = JSON.parse(fileNameMatch[1]);
+
+            // this removes file extension docx and adds pdf file extension.
+            if (fileName.endsWith('.docx')) {
+                fileName = fileName.slice(0, -5) + '.pdf';
+            }
+
+            return fileName;
         }
 
         function downloadFile(blob, fileName) {

--- a/content.js
+++ b/content.js
@@ -44,7 +44,7 @@
 
             const parsedLink = getDownloadLink(html);
             if (!parsedLink) {
-                console.error('[StudyDrive Download] Download link not found', html);
+                console.error('[StudyDrive Download] Download link not found');
                 return;
             }
 

--- a/content.js
+++ b/content.js
@@ -49,6 +49,10 @@
             }
 
             const fileName = getFileName(html);
+            if (!fileName) {
+                console.error('[StudyDrive Download] File Extension not supported');
+                return;
+            }
 
             const downloadResult = await fetch(parsedLink);
             const blob = await downloadResult.blob();
@@ -73,6 +77,11 @@
             // this removes file extension docx and adds pdf file extension.
             if (fileName.endsWith('.docx')) {
                 fileName = fileName.slice(0, -5) + '.pdf';
+            }
+
+            // this is to ensure only pdfs are downloaded.
+            if (!fileName.endsWith('.pdf')) {
+                return null;
             }
 
             return fileName;


### PR DESCRIPTION
Hey. i use this product sometimes and found had same issue as #2 and fixed it. additionally, i removed "html" from error messages to not bloat console with unneeded information. furthermore i added to not download when we have not .pdf files, since ZIP's can be uploaded on studydrive aswell and you cant download them with this extension.